### PR TITLE
Remove receive method.

### DIFF
--- a/src/BulkRegistration.sol
+++ b/src/BulkRegistration.sol
@@ -187,9 +187,4 @@ contract BulkRegistration is ReverseClaimer {
             if (!success) revert RefundFailed();
         }
     }
-
-    /**
-     * @notice Accept ETH transfers (needed to receive controller refunds during registration)
-     */
-    receive() external payable {}
 }


### PR DESCRIPTION
Controller refunds are not possible because we check the price in the same block so we always pay exactly what we owe.
The registration is atomic and the controller never sends eth back to refund the user.